### PR TITLE
fix(cache): Prevent caching of SERVFAIL and NXDOMAIN responses

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -205,6 +205,11 @@ func (c *Cache) Get(key string) (*dns.Msg, bool, bool) {
 
 // Set adds a message to the cache.
 func (c *Cache) Set(key string, msg *dns.Msg, swr, prefetch time.Duration) {
+	// Do not cache responses with SERVFAIL or NXDOMAIN RCODEs.
+	if msg.Rcode == dns.RcodeServerFailure || msg.Rcode == dns.RcodeNameError {
+		return
+	}
+
 	shard := c.getShard(key)
 	shard.Lock()
 	defer shard.Unlock()


### PR DESCRIPTION
This change modifies the cache's Set function to prevent DNS responses with `SERVFAIL` or `NXDOMAIN` rcodes from being cached.

This is done by checking the `Rcode` of the incoming message at the beginning of the `Set` function. If the `Rcode` matches `dns.RcodeServerFailure` or `dns.RcodeNameError`, the function returns early, and the message is not added to the cache.